### PR TITLE
Fix: append all slice data when range for it

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -838,7 +838,7 @@ func keyspaceParamsToKeyspaces(ctx context.Context, wr *wrangler.Wrangler, param
 		}
 		if param[0] == '/' {
 			// this is a topology-specific path
-			result = append(result, params...)
+			result = append(result, param)
 		} else {
 			// this is not a path, so assume a keyspace name,
 			// possibly with wildcards


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

I am writing a linter called [sundrylint](https://github.com/alingse/sundrylint) to address some real-world bugs that I discovered during my work.

When we range over a slice and call the append function within the loop body, we are not appending all elements, but only the ones that we specifically iterate over during the range operation.

```go
for _, n := range ns {
   rs = append(rs, n)       # this is mostly wanted
   rs = append(rs, ns...)   # this is mostly wrong
}
```
I read the code in here and I think it was just want to append that one `param` to `result`
## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
